### PR TITLE
[22-09-27] 참여하기, 즐겨찾기 Response 수정

### DIFF
--- a/src/main/java/com/havit/finalbe/controller/FavoriteController.java
+++ b/src/main/java/com/havit/finalbe/controller/FavoriteController.java
@@ -19,7 +19,7 @@ public class FavoriteController {
 
     @Operation(summary = "그룹 즐겨찾기", description = "해당하는 그룹을 즐겨찾기/즐겨찾기 취소 합니다.")
     @PostMapping("/api/auth/favorite")
-    public ResponseDto<?> favorites(@RequestBody FavoriteDto favoriteDto, HttpServletRequest request) {
-        return favoriteService.favorites(favoriteDto, request);
+    public ResponseDto<?> favorites(@RequestBody FavoriteDto.Request favoriteRequestDto, HttpServletRequest request) {
+        return favoriteService.favorites(favoriteRequestDto, request);
     }
 }

--- a/src/main/java/com/havit/finalbe/dto/CommentDto.java
+++ b/src/main/java/com/havit/finalbe/dto/CommentDto.java
@@ -17,7 +17,7 @@ public class CommentDto {
     @NoArgsConstructor
     public static class Request {
 
-        @Schema(description = "인증 id", example = "1")
+        @Schema(description = "인증샷 id", example = "1")
         private Long certifyId;
 
         @Schema(description = "댓글 내용", example = "오늘도 6시에 일어나느라 수고하셨습니다!")

--- a/src/main/java/com/havit/finalbe/dto/FavoriteDto.java
+++ b/src/main/java/com/havit/finalbe/dto/FavoriteDto.java
@@ -1,18 +1,59 @@
 package com.havit.finalbe.dto;
 
+import com.havit.finalbe.entity.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Schema(description = "즐겨찾기 DTO")
-@Builder
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 public class FavoriteDto {
 
-    @Schema(description = "그룹 id", example = "1")
-    private Long groupId;
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+
+        @Schema(description = "그룹 id", example = "1")
+        private Long groupId;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+
+        @Schema(description = "그룹 id", example = "1")
+        private Long groupId;
+
+        @Schema(description = "그룹명", example = "아침 6시 기상러들")
+        private String title;
+
+        @Schema(description = "그룹 이미지", example = "aws 이미지 Url")
+        private String imgUrl;
+
+        @Schema(description = "멤버 수", example = "15")
+        private int memberCount;
+
+        @Schema(description = "그룹 태그")
+        private List<String> groupTag;
+
+        @Schema(description = "즐겨찾기", example = "true")
+        private boolean favorite;
+
+        @Schema(description = "작성 일시", example = "2022-07-25T12:43:01.226062")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "수정 일시", example = "2022-07-25T12:43:01.226062")
+        private LocalDateTime modifiedAt;
+
+        @Schema(description = "멤버 정보")
+        private Member member;
+    }
 }

--- a/src/main/java/com/havit/finalbe/service/ParticipateService.java
+++ b/src/main/java/com/havit/finalbe/service/ParticipateService.java
@@ -131,7 +131,45 @@ public class ParticipateService {
                     .member(member)
                     .build();
             participateRepository.delete(participate);
-            return ResponseDto.success("참여 취소가 완료되었습니다.");
+
+            // 태그 가져오기
+            List<String> tagListByGroup = serviceUtil.getTagNameListFromGroupTag(groups);
+
+            // 참여한 멤버 카운팅
+            int memberCount = participateRepository.countByGroups_GroupId(groupId);
+
+            // 참여 멤버 목록
+            List<Participate> participateList = participateRepository.findAllByGroups(groups);
+            List<Member> memberList = new ArrayList<>();
+            for (Participate participateMember : participateList) {
+                memberList.add(participateMember.getMember());
+            }
+
+            // 인증샷 이미지 URL 목록 가져오기
+            List<Certify> certifyList = certifyRepository.findByGroups_GroupId(groupId);
+            List<String> certifyImgUrlList = new ArrayList<>();
+            for (Certify imgUrl : certifyList) {
+                certifyImgUrlList.add(imgUrl.getImgUrl());
+            }
+
+            return ResponseDto.success(
+                    GroupDto.Response.builder()
+                            .groupId(groupId)
+                            .title(groups.getTitle())
+                            .nickname(groups.getMember().getNickname())
+                            .leaderName(groups.getLeaderName())
+                            .crewName(groups.getCrewName())
+                            .startDate(groups.getStartDate())
+                            .content(groups.getContent())
+                            .imgUrl(groups.getImgUrl())
+                            .createdAt(groups.getCreatedAt())
+                            .modifiedAt(groups.getModifiedAt())
+                            .groupTag(tagListByGroup)
+                            .memberCount(memberCount)
+                            .memberList(memberList)
+                            .certifyImgUrlList(certifyImgUrlList)
+                            .build()
+            );
         }
 
         return ResponseDto.fail(PARTICIPATION_NOT_FOUND);


### PR DESCRIPTION
# 수정사항
- 그룹 참여 취소 시, 그룹 객체 반환 설정
- 즐겨찾기 응답에 그룹, 멤버 객체 반환 설정

## 그룹 참여하기 Response (POST)
<img width="610" alt="그룹 참여하기" src="https://user-images.githubusercontent.com/110372162/192428369-8c2ee2f9-31e9-4bdb-87a5-e21c74367ea2.png">

## 그룹 참여하기 취소 Response (DELETE)
<img width="576" alt="그룹 참여하기 취소" src="https://user-images.githubusercontent.com/110372162/192428405-10e89ace-d6b8-4b39-afe0-cfd1b02fb475.png">

---

## 그룹 즐겨찾기 Response (POST)
<img width="596" alt="그룹 즐겨찾기" src="https://user-images.githubusercontent.com/110372162/192428503-d55b1ee2-f651-4b8b-a083-37abb35d38e2.png">

## 그룹 즐겨찾기 취소 Response (POST)
<img width="587" alt="그룹 즐겨찾기 취소" src="https://user-images.githubusercontent.com/110372162/192428539-cbbf6c93-b176-49dc-b6be-dd5f0771a1ec.png">
