### PR TITLE
[22-10-02] 랜덤 프로필 이미지 기능 구현

### DIFF
--- a/src/main/java/com/havit/finalbe/controller/ImageController.java
+++ b/src/main/java/com/havit/finalbe/controller/ImageController.java
@@ -28,4 +28,16 @@ public class ImageController {
     public String deleteImage(@PathVariable Long imageId) {
         return imageService.deleteImage(imageId);
     }
+
+    @Operation(summary = "랜덤 이미지 업로드", description = "랜덤 프로필로 쓸 이미지를 첨부합니다.")
+    @PostMapping("/random")
+    public Long randomImgUpload(@RequestPart(value = "image") MultipartFile multipartFile) throws IOException {
+        return imageService.randomImgUpload(multipartFile, "random");
+    }
+
+    @Operation(summary = "랜덤 이미지 id", description = "프로필로 쓸 이미지 id를 랜덤으로 불러옵니다.")
+    @GetMapping("/random")
+    public int getRandomProfileId() {
+        return imageService.randomImage();
+    }
 }

--- a/src/main/java/com/havit/finalbe/entity/RandomProfile.java
+++ b/src/main/java/com/havit/finalbe/entity/RandomProfile.java
@@ -1,0 +1,30 @@
+package com.havit.finalbe.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class RandomProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long randomId;
+
+    @Column(nullable = false)
+    private String savePath;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(length = 20, nullable = false)
+    private String extension;
+
+    @Column(nullable = false)
+    private Long size;
+}

--- a/src/main/java/com/havit/finalbe/repository/RandomProfileRepository.java
+++ b/src/main/java/com/havit/finalbe/repository/RandomProfileRepository.java
@@ -1,0 +1,9 @@
+package com.havit.finalbe.repository;
+
+import com.havit.finalbe.entity.RandomProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RandomProfileRepository extends JpaRepository<RandomProfile, Long> {
+}


### PR DESCRIPTION
# 랜덤 프로필 이미지 기능

## POST
첨부 방법은 기존 이미지 첨부 방식과 같으며, S3에 폴더만 다르게 저장됩니다.
랜덤 프로필 이미지용 RandomProfile 테이블이 새로 생성 되었습니다. 현재 준묵님께서 주신 1~11번 이미지까지 저장되어 있습니다.
<img width="489" alt="스크린샷 2022-10-02 오후 3 51 25" src="https://user-images.githubusercontent.com/110372162/193441888-1851af62-cf27-45bb-913e-2910e5d51ae5.png">

## GET
저장된 이미지의 아이디를 랜덤으로 출력합니다. 
<img width="494" alt="스크린샷 2022-10-02 오후 3 55 08" src="https://user-images.githubusercontent.com/110372162/193441994-5b23719e-cab4-4e11-a135-61dc9a997f85.png">
