### PR TITLE
[22-10-13] 다른 멤버 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/havit/finalbe/controller/MemberController.java
+++ b/src/main/java/com/havit/finalbe/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.havit.finalbe.controller;
 
 import com.havit.finalbe.dto.request.LoginRequestDto;
 import com.havit.finalbe.dto.request.SignupRequestDto;
+import com.havit.finalbe.dto.response.MemberProfileResponseDto;
 import com.havit.finalbe.dto.response.MemberResponseDto;
 import com.havit.finalbe.dto.response.MessageResponseDto;
 import com.havit.finalbe.security.userDetail.UserDetailsImpl;
@@ -49,8 +50,14 @@ public class MemberController {
 
     @Operation(summary = "로그인 멤버 정보", description = "로그인한 멤버 정보를 반환합니다.")
     @GetMapping("/auth/info")
-    public MemberResponseDto getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return memberService.getMemberInfo(userDetails);
+    public MemberResponseDto getMyInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return memberService.getMyInfo(userDetails);
+    }
+
+    @Operation(summary = "다른 멤버 정보", description = "다른 멤버 정보를 조회합니다.")
+    @GetMapping("/auth/info/{memberId}")
+    public MemberProfileResponseDto getMemberInfo(@PathVariable Long memberId) {
+        return memberService.getMemberInfo(memberId);
     }
 
 }

--- a/src/main/java/com/havit/finalbe/dto/response/MemberProfileResponseDto.java
+++ b/src/main/java/com/havit/finalbe/dto/response/MemberProfileResponseDto.java
@@ -13,8 +13,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "멤버 응답 DTO")
-public class MemberResponseDto {
+@Schema(description = "멤버별 프로필 응답 DTO")
+public class MemberProfileResponseDto {
 
     @Schema(description = "멤버 id", example = "1")
     private Long memberId;
@@ -37,6 +37,9 @@ public class MemberResponseDto {
     @Schema(description = "수정 일시", example = "2022-07-25T12:43:01.226062")
     private LocalDateTime modifiedAt;
 
-    @Schema(description = "내가 작성한 인증샷 목록")
+    @Schema(description = "해당 멤버가 참여한 그룹 목록")
+    private List<AllGroupListResponseDto> groupList;
+
+    @Schema(description = "해당 멤버가 작성한 인증샷 목록")
     private List<CertifyResponseDto> certifyList;
 }

--- a/src/main/java/com/havit/finalbe/repository/CertifyRepository.java
+++ b/src/main/java/com/havit/finalbe/repository/CertifyRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface CertifyRepository extends JpaRepository<Certify, Long> {
     List<Certify> findByGroups_GroupIdOrderByCreatedAtDesc(Long groupId);
     List<Certify> findByCreatedDateAndMember_MemberIdAndGroups_GroupId(LocalDate yesterday, Long memberId, Long groupId);
+    List<Certify> findAllByMember_MemberId(Long memberId);
 }


### PR DESCRIPTION
`다른 멤버 정보 조회` 기능 구현하면서 프론트 요청으로 기존 `토큰에서 멤버 정보 가져오기` 기능에 CertifyList도 같이 불러오게끔 추가했습니다.